### PR TITLE
Fix permissions on job to allow write the comment

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
 name: Pull request
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ main ]
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   execute-action:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
There are some limitations to using GITHUB_TOKEN when writing comments from fork-based repositories. https://docs.github.com/en/rest/using-the-rest-api/troubleshooting-the-rest-api?apiVersion=2022-11-28#resource-not-accessible
This workaround allows us to create comments from fork-based repositories
